### PR TITLE
more examples and subsequently removing support for floating precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 But might not make as much sense. `f` is for "format". `align` is self explanatory. Stay tuned. All will become clear.
 
 ## Overview
-`falign` is a smart and powerful formatter and parser. Anything (_almost anything_) `format` is capable of formatting may be parsed using the same format specification.  The specification we devised picks and chooses some of our favorite qualities from c's `sprintf` and python's `format` and adds some of our flavor crystals.  We tossed and turned the problem over in our heads and decided to make one big assumption which is that _almost_ everything is formatted (not necessarily parsed) as a string. We do include some basic support for specifiers such as numeric precision..
+`falign` is a smart and powerful formatter and parser. Anything (_almost anything_) `format` is capable of formatting may be parsed using the same format specification.  The specification we devised picks and chooses some of our favorite qualities from c's `sprintf` and python's `format` and adds some of our flavor crystals.  We tossed and turned the problem over in our heads and decided to make one big assumption which is that everything is formatted as a string.
 
 _"Hey, why do that?"_, you ask. _"I loose my ability to convert and format a number as hexadecimal. I loose my ability to format my dates according to some calendar on some far off planet in some galaxy far far away!"_  Do you? No, you don't. No formatting library will ever be able to present the bits and pieces of your data in all of the various ways you want to format it. `falign`'s concern is formatting the whole. You know how you want to present the bits and pieces of your data. Format your `Date` your `Objects`, your special sauce however you like if `toString` doesn't cut it. 
 
@@ -20,19 +20,19 @@ Feeling better? No. Well, checkout the specification. Check out the API. Check o
 The following are all results from our [examples](./examples/.). To run the examples _NodeJS_ must be installed.
 
 ### Format alignment examples - `./examples/format-lrc.js`
-**description**: _lrc - padding=" ", width=10, paths=default_
+**description**: _left/right/center - padding=" ", width=10_
 ```
 request: format("${10l}|${10c}|${10r}", ["left", "center", "right"])
 result: "left      |  center  |     right"
 ```
 
-**description**: _lrc - padding=".", width=15, paths=indexes_
+**description**: _left/right/center - padding=".", paths=indexes, width=15_
 ```
 request: format("${0:.15l}|${1:.15c}|${0:.15r}", ["element-0","element-1"])
 result: "element-0......|...element-1...|......element-0"
 ```
 
-**description**: _lrc - padding=".", width=15, paths=object_
+**description**: _left/right/center - padding=".", paths=object, width=15_
 ```
 request: format("${left:.15l}|${center:.15c}|${right:.15r}", 
    {"center": "dead-eye", "left": "leftie", "right": "rightie"})
@@ -40,42 +40,84 @@ result: "leftie.........|...dead-eye....|........rightie"
 ```
 
 ### Parse alignment examples - `./examples/parse-lrc.js`
-**description**: _lrc - padding=" ", width=10, paths=default_
+**description**: _left/right/center - padding=" ", width=10_
 ```
 request: parse("${10l}|${10c}|${10r}", "left      |  center  |     right")
 result: ["left", "center", "right"]
 ```
 
-**description**: _lrc - padding=".", width=15, paths=indexes_
+**description**: _left/right/center - padding=".", paths=indexes, width=15_
 ```
 request: parse("${0:.15l}|${1:.15c}|${0:.15r}", "element-0......|...element-1...|......element-0")
 result: ["element-0", "element-1"]
 ```
 
-**description**: _lrc - padding=".", width=15, paths=object_
+**description**: _left/right/center - padding=".", paths=object, width=15_
 ```
 request: parse("${left:.15l}|${center:.15c}|${right:.15r}", 
    "leftie.........|...dead-eye....|........rightie")
 result: {"left": "leftie", "center": "dead-eye", "right": "rightie"}
 ```
 
+### Format literal examples - `./examples/format-literals.js`
+**description**: _fields and literals - align=left_
+```
+request: format("${l} + ${l} = ${l}", [50, 25, 75])
+result: "50 + 25 = 75"
+```
+
+**description**: _fields and literals - align=left_
+```
+request: format("${l} + ${l} = ${l}", [50.5, 25.25, 75.75])
+result: "50.5 + 25.25 = 75.75"
+```
+
+**description**: _fields and literals w/precision - align=left_
+```
+request: format("${l} + ${l} ~= ${l}", [50.5, 25.25, "75.8"])
+result: "50.5 + 25.25 ~= 75.8"
+```
+
+### Parse literal examples - `./examples/parse-literals.js`
+**description**: _fields and literals - align=left_
+```
+request: parse("${l} + ${l} = ${l}", "50 + 25 = 75")
+result: ["50", "25", "75"]
+```
+
+**description**: _fields and literals - align=left, type=integer_
+```
+request: parse("${li} + ${li} = ${li}", "50 + 25 = 75")
+result: [50, 25, 75]
+```
+
+**description**: _fields and literals - align=left, type=float_
+```
+request: parse("${lf} + ${lf} = ${lf}", "50.5 + 25.25 = 75.75")
+result: [50.5, 25.25, 75.75]
+```
+
+**description**: _fields and literals - align=left, type=float_
+```
+request: parse("${lf} + ${lf} ~= ${lf}", "50.5 + 25.25 ~= 75.8")
+result: [50.5, 25.25, 75.8]
+```
+
 ## Specification
 
 ### format
 The format specification is a `string`. It may be composed of literals and optional _fields_. 
- The _field_ specification is as follows: `"${[path:][pad][width][.precision]<l|r|c>}"`
+ The _field_ specification is as follows: `"${[path:][pad][width]<l|r|c>}"`
  * `path`: optional property path of the data in `format`'s `data` param. Defaults to the _field_ spec's index.
  * `pad`: optional character to pad with. It may not be 1-9. And `width` must be included for it to be useful. Defaults to a space.
  * `width`: optional width of field in characters.
- * `precision`: optional floating point precision. In this case the value will be treated as a `number`.
  * `l|r|c`: align left, right or center
 
 ### parse
-The parse specification is a superset of the _format_ specification. Its motivations for being an extension of the _format_ specification is that we offer an optional _type_ directive. These allow us to know how to parse some simple _field_ types such as _numbers_ and _dates_. The _field_ specification is as follows: `"${[path:][pad][width][.precision]<l|r|c>[i|f|d][+]}"`
+The parse specification is a superset of the _format_ specification. Its motivations for being an extension of the _format_ specification is that we offer an optional _type_ directive. These allow us to know how to parse some simple _field_ types such as _numbers_ and _dates_. The _field_ specification is as follows: `"${[path:][pad][width]<l|r|c>[i|f|d][+]}"`
  * `path`: optional property path of the parsed value in the result object. Defaults to the _field_ spec's index.
  * `pad`: optional character the field is padded with. It may not be 1-9.
  * `width`: optional width of field in characters.
- * `precision`: optional floating point precision. _Not used at the moment. Can't see that it will ever have value._
  * `l|r|c`: aligned left, right or center.
  * `i|f|d`: optional conversion type for the field: `i`=integer, `f`=floating point, `d`=date. `string` by default.
  * `+`: optional flag which reads to end of the line. Useful for variable length fields at the end of a line.

--- a/examples/format-literals.js
+++ b/examples/format-literals.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Date: 2019-05-05 20:26
+ * @license MIT (see project's LICENSE file)
+ */
+
+const run=require("./_run");
+
+run.format("fields and literals - align=left",
+	"${l} + ${l} = ${l}",
+	[50, 25, 50+25]
+);
+
+run.format("fields and literals - align=left",
+	"${l} + ${l} = ${l}",
+	[50.5, 25.25, 50.5+25.25]
+);
+
+run.format("fields and literals w/precision - align=left",
+	"${l} + ${l} ~= ${l}",
+	[50.5, 25.25, (50.5+25.25).toFixed(1)]
+);

--- a/examples/format-lrc.js
+++ b/examples/format-lrc.js
@@ -6,17 +6,17 @@
 
 const run=require("./_run");
 
-run.format("lrc - padding=' ', width=10, paths=default",
+run.format('left/right/center - padding=" ", width=10',
 	"${10l}|${10c}|${10r}",
 	["left", "center", "right"]
 );
 
-run.format("lrc - padding='.', width=15, paths=indexes",
+run.format('left/right/center - padding=".", paths=indexes, width=15',
 	"${0:.15l}|${1:.15c}|${0:.15r}",
 	["element-0", "element-1"]
 );
 
-run.format("lrc - padding='.', width=15, paths=object",
+run.format('left/right/center - padding=".", paths=object, width=15',
 	"${left:.15l}|${center:.15c}|${right:.15r}",
 	{
 		center: "dead-eye",

--- a/examples/parse-literals.js
+++ b/examples/parse-literals.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Date: 2019-05-05 20:32
+ * @license MIT (see project's LICENSE file)
+ */
+
+const run=require("./_run");
+
+run.parse("fields and literals - align=left",
+	"${l} + ${l} = ${l}",
+	"50 + 25 = 75"
+);
+
+run.parse("fields and literals - align=left, type=integer",
+	"${li} + ${li} = ${li}",
+	"50 + 25 = 75"
+);
+
+run.parse("fields and literals - align=left, type=float",
+	"${lf} + ${lf} = ${lf}",
+	"50.5 + 25.25 = 75.75"
+);
+
+run.parse("fields and literals - align=left, type=float",
+	"${lf} + ${lf} ~= ${lf}",
+	"50.5 + 25.25 ~= 75.8"
+);

--- a/examples/parse-lrc.js
+++ b/examples/parse-lrc.js
@@ -6,17 +6,17 @@
 
 const run=require("./_run");
 
-run.parse("lrc - padding=' ', width=10, paths=default",
+run.parse('left/right/center - padding=" ", width=10',
 	"${10l}|${10c}|${10r}",
 	"left      |  center  |     right"
 );
 
-run.parse("lrc - padding='.', width=15, paths=indexes",
+run.parse('left/right/center - padding=".", paths=indexes, width=15',
 	"${0:.15l}|${1:.15c}|${0:.15r}",
 	"element-0......|...element-1...|......element-0"
 );
 
-run.parse("lrc - padding='.', width=15, paths=object",
+run.parse('left/right/center - padding=".", paths=object, width=15',
 	"${left:.15l}|${center:.15c}|${right:.15r}",
 	"leftie.........|...dead-eye....|........rightie"
 );

--- a/lib/_utils.js
+++ b/lib/_utils.js
@@ -1,0 +1,24 @@
+/**
+ * Date: 2019-05-05 21:32
+ * @license MIT (see project's LICENSE file)
+ /**
+
+
+ /**
+ * Escapes reserved regex characters.
+ * @param {string} text
+ * @return {string}
+ */
+function escapeRegexLiteral(text) {
+	let match;
+	const regex=/(\^|\$|\.|\*|\?|\+|\(|\[)/g;
+	while((match=regex.exec(text))!==null) {
+		text=`${text.substr(0, regex.lastIndex-1)}\\${match[0]}${text.substr(regex.lastIndex)}`;
+		regex.lastIndex++;
+	}
+	return text;
+}
+
+module.exports={
+	escapeRegexLiteral
+};

--- a/lib/format.js
+++ b/lib/format.js
@@ -13,11 +13,10 @@ const _=require("lodash");
 /**
  * Formats the data in <param>blob<param>. We are using a somewhat hybrid approach to formatting. It's a little
  * sprintf, it's a little es6 template and it's a little custom.
- * The format spec is as follows: "${[path:][pad][width][.precision]<l|r|c>}":
+ * The format spec is as follows: "${[path:][pad][width]<l|r|c>}":
  * - path: optional property path of the data in <param>data</param>. Defaults to field spec index.
  * - pad: optional character to pad with. It may not be 1-9. And width must be included for it to be useful.
  * - width: optional width of field in characters.
- * - precision: optional floating point precision
  * - l|r|c: align left, right or center
  * @param {string} format
  * @param {Array|Object} data
@@ -26,7 +25,7 @@ const _=require("lodash");
  */
 module.exports=function(format, data) {
 	let result=format;
-	const regex=/(\$\\{)|(\${([^:]+?:)?([^1-9])?(\d+)?(\.\d+)?([lrc])})/g;
+	const regex=/(\$\\{)|(\${([^:]+?:)?([^1-9])?(\d+)?([lrc])})/g;
 	for(let match, index=0; (match=regex.exec(result)); index++) {
 		if(match[1]!==undefined) {
 			result=`${result.substr(0, match.index)}$\{${result.substr(regex.lastIndex)}`;
@@ -40,11 +39,9 @@ module.exports=function(format, data) {
 					return "undefined";
 				} else if(data===null) {
 					return "null";
-				} else if(precision!==undefined) {
-					return _assertType(data, "Number")
-						.toFixed(precision);
+				} else {
+					return String(data);
 				}
-				return String(data);
 			}
 
 			/**
@@ -71,8 +68,7 @@ module.exports=function(format, data) {
 			let path=(match[3]!==undefined) ? match[3].substr(0, match[3].length-1) : index,
 				fill=match[4] || " ",
 				width=(match[5]!==undefined) ? Number(match[5]) : undefined,
-				precision=(match[6]!==undefined) ? Number(match[6].substr(1)) : undefined,
-				align=match[7],
+				align=match[6],
 				format=_.get(data, path);
 			if(format===undefined) {
 				throw new Error(`data[${path}] cannot be found`);
@@ -85,19 +81,3 @@ module.exports=function(format, data) {
 	}
 	return result;
 };
-
-/**
- * Asserts the type is of the (constructor) type specified by <param>type</param>
- * @param {*} value
- * @param {string} type
- * @returns {*}
- * @throws {Error}
- * @private
- */
-function _assertType(value, type) {
-	if(value==null || value.constructor.name!==type) {
-		throw new Error(`expecting ${type} but found "${value}"`);
-	}
-	return value;
-}
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ module.exports={
 	},
 
 	/**
-	 * @returns {Function(format:string, encoded:string, {exceptionOnMismatch:boolean}):(Array<*>|string)}
+	 * @returns {function(format:string, encoded:string, {exceptionOnMismatch:boolean}):(Array<*>|string)}
 	 */
 	get parse() {
 		return (storage.parse)

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,6 +7,7 @@
  */
 
 const _=require("lodash");
+const {escapeRegexLiteral}=require("./_utils");
 
 /* eslint-disable no-inner-declarations */
 
@@ -15,11 +16,10 @@ const _=require("lodash");
  * 100% accuracy provided <param>encoded</param> does not fall out of bounds. But if widths are not included then this function
  * does it's best by looking for padded boundaries. But should one field butt up against another it is impossible for this
  * function to know exactly where the division should be made and the results you get probably aren't the ones you are expecting.
- * The format spec is as follows: "${[path:][pad][width][.precision]<l|r|c>[i|f|d][+]}"
+ * The format spec is as follows: "${[path:][pad][width]<l|r|c>[i|f|d][+]}"
  * - path: optional property path of the value in the result. Defaults to field spec index.
  * - pad: optional character field is padded with. It may not be 1-9.
  * - width: optional width of field in characters.
- * - precision: optional floating point precision
  * - l|r|c: aligned left, right or center
  * - i|f|d: optional conversion type for the field: i=integer, f=floating point, d=date. String by default.
  * - +: optional flag which reads to end of the line. Useful for variable length fields at the end of a line.
@@ -39,19 +39,19 @@ module.exports=function(format, encoded, {
 	function _getFieldSpecifiers() {
 		let result=[];
 		const matches=[],
-			regex=/(\${([^:]+?:)?([^1-9])?(\d+)?(\.\d+)?([lrc])([dfi]?)([+]?)})/g;
+			regex=/(\${([^:]+?:)?([^1-9])?(\d+)?([lrc])([dfi]?)([+]?)})/g;
 		for(let match, index=0; (match=regex.exec(format)); index++) {
 			let lastSpecEndIndex=(index>0)
 				? matches[index-1].specEndIndex
 				: 0,
 				parsed={
+					field: match[0],
 					fieldPath: (match[2]!==undefined) ? match[2].substr(0, match[2].length-1) : index,
 					fieldFill: match[3] || " ",
 					fieldWidth: (match[4]!==undefined) ? Number(match[4]) : undefined,
-					fieldPrecision: (match[5]!==undefined) ? Number(match[5].substr(1)) : undefined,
-					fieldAlign: match[6],
-					fieldType: match[7],
-					fieldFlag: match[8],
+					fieldAlign: match[5],
+					fieldType: match[6],
+					fieldFlag: match[7],
 					specEndIndex: regex.lastIndex,
 					specStartIndex: match.index,
 					specPrefix: format.substr(lastSpecEndIndex, match.index-lastSpecEndIndex)
@@ -90,13 +90,13 @@ module.exports=function(format, encoded, {
 	const {matches, result}=_getFieldSpecifiers();
 	for(let index=0; index<matches.length; index++) {
 		let {
+			field,
 			fieldAlign,
 			fieldFill,
 			fieldFlag,
 			fieldPath,
 			fieldWidth,
 			fieldType,
-			match,
 			specPrefix,
 			specStartIndex,
 			specEndIndex
@@ -144,7 +144,7 @@ module.exports=function(format, encoded, {
 				}
 				case "r":
 				case "c": {
-					const fieldFillEscaped=_escapeRegexCharacter(fieldFill),
+					const fieldFillEscaped=escapeRegexLiteral(fieldFill),
 						regex=new RegExp(`^${fieldFillEscaped}*([^${fieldFill}]*)`),
 						match=regex.exec(data);
 					return _.get(match, "1");
@@ -162,9 +162,9 @@ module.exports=function(format, encoded, {
 			const data=encoded.substring(lastEncodedEndIndex);
 			switch(fieldAlign) {
 				case "l": {
-					const suffix=_.get(matches[index+1], "specPrefix", ""),
-						fieldFillEscaped=_escapeRegexCharacter(fieldFill),
-						regex=new RegExp(`^(([^${fieldFill}]*)${fieldFillEscaped}*)${suffix}`),
+					const suffixEscaped=escapeRegexLiteral(_.get(matches[index+1], "specPrefix", "")),
+						fieldFillEscaped=(fieldFill),
+						regex=new RegExp(`^(([^${fieldFill}]*)${fieldFillEscaped}*)${suffixEscaped}`),
 						match=regex.exec(data);
 					return (match===null)
 						? null
@@ -175,7 +175,7 @@ module.exports=function(format, encoded, {
 				}
 				case "r": {
 					const trailingFill=_.get(matches[index+1], "fieldFill", fieldFill),
-						fieldFillEscaped=_escapeRegexCharacter(fieldFill),
+						fieldFillEscaped=escapeRegexLiteral(fieldFill),
 						regex=new RegExp(`^${fieldFillEscaped}*([^${trailingFill}]*)`),
 						match=regex.exec(data);
 					return (match===null)
@@ -186,9 +186,9 @@ module.exports=function(format, encoded, {
 						};
 				}
 				case "c": {
-					const suffix=_.get(matches[index+1], "specPrefix", ""),
-						fieldFillEscaped=_escapeRegexCharacter(fieldFill),
-						regex=new RegExp(`^(${fieldFillEscaped}*([^${fieldFillEscaped}]*)${fieldFillEscaped}*)${suffix}`),
+					const suffixEscaped=escapeRegexLiteral(_.get(matches[index+1], "specPrefix", "")),
+						fieldFillEscaped=escapeRegexLiteral(fieldFill),
+						regex=new RegExp(`^(${fieldFillEscaped}*([^${fieldFillEscaped}]*)${fieldFillEscaped}*)${suffixEscaped}`),
 						match=regex.exec(data);
 					return (match===null)
 						? null
@@ -238,15 +238,15 @@ module.exports=function(format, encoded, {
 			let encodedField=encoded.substr(lastEncodedEndIndex, fieldWidth),
 				depadded=_depad(encodedField);
 			if(depadded===undefined) {
-				return _processFailure(`could not parse "${encodedField}" with "${match[0]}"`);
+				return _processFailure(`could not parse "${encodedField}" with "${field}"`);
 			} else {
 				_.set(result, fieldPath, _convert(depadded));
 				lastEncodedEndIndex+=fieldWidth;
 			}
 		} else {
 			let deciphered=_decipher();
-			if(deciphered===undefined) {
-				return _processFailure(`could not match "${match[0]}"`);
+			if(deciphered===null) {
+				return _processFailure(`could not match "${field}"`);
 			} else {
 				_.set(result, fieldPath, _convert(deciphered.data));
 				lastEncodedEndIndex+=deciphered.length;
@@ -261,15 +261,3 @@ module.exports=function(format, encoded, {
 	}
 	return result;
 };
-
-/**
- * Escapes reserved regex characters.
- * @param {string} character
- * @return {string}
- * @private
- */
-function _escapeRegexCharacter(character) {
-	return ("^$.*?+([".indexOf(character)>-1)
-		? `\\${character}`
-		: character;
-}

--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
 		"lint": "eslint --config ./node_modules/pig-quality/server.eslintrc.json examples/**/*.js lib/**/*.js test/**/*.js",
 		"test": "mocha --recursive test/**/*.js"
 	},
-	"version": "1.0.1"
+	"version": "1.1.0"
 }

--- a/test/test-_utils.js
+++ b/test/test-_utils.js
@@ -1,0 +1,41 @@
+/**
+ * Date: 2019-05-05 21:34
+ * @license MIT (see project's LICENSE file)
+ */
+
+const assert=require("assert");
+const utils=require("../lib/_utils");
+
+describe("lib._utils", function() {
+	describe("escapeRegexLiteral", function() {
+		[
+			["a"],
+			["abc"],
+			["1"],
+			["123"]
+		].forEach(character=>{
+			it(`should not escape ${character}`, function() {
+				const result=utils.escapeRegexLiteral(character);
+				assert.strictEqual(result, character);
+			});
+		});
+
+		[
+			["^", "\\^"],
+			["$", "\\$"],
+			[".", "\\."],
+			["*", "\\*"],
+			["?", "\\?"],
+			["+", "\\+"],
+			["(", "\\("],
+			["[", "\\["],
+			["a + b", "a \\+ b"],
+			["^ .+ $", "\\^ \\.\\+ \\$"],
+		].forEach(([character, expected])=>{
+			it(`should escape ${character}`, function() {
+				const result=utils.escapeRegexLiteral(character);
+				assert.strictEqual(result, expected);
+			});
+		});
+	});
+});

--- a/test/test-format.js
+++ b/test/test-format.js
@@ -51,10 +51,7 @@ describe("src.format", function() {
 		["${03r}", [5], "005"],
 		["${*3l}", [5], "5**"],
 		["${*3c}", [5], "*5*"],
-		["${*3r}", [5], "**5"],
-		["${6.2l}", [5.1234], "5.12  "],
-		["${6.2c}", [5.1234], " 5.12 "],
-		["${6.2r}", [5.1234], "  5.12"]
+		["${*3r}", [5], "**5"]
 	].forEach(([spec, data, expected])=>{
 		it(`should properly apply format options for spec ${spec} and ${JSON.stringify(data)}`, function() {
 			assert.strictEqual(format(spec, data), expected);
@@ -69,6 +66,13 @@ describe("src.format", function() {
 	].forEach(([spec, data, expected])=>{
 		it(`should properly format more complex configuration: spec=${spec} and data=${JSON.stringify(data)}`, function() {
 			assert.strictEqual(format(spec, data), expected);
+		});
+	});
+
+	describe("examples", function() {
+		it("should successfully format: add - padding=[none], paths=default, width=[none]", function() {
+			const result=format("${l} + ${l} = ${.1l}", [50.5, 25.25, 75.75]);
+			assert.strictEqual(result, "50.5 + 25.25 = 75.75");
 		});
 	});
 });

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -164,19 +164,34 @@ describe("src.parse", function() {
 	});
 
 	describe("examples", function() {
-		it('should successfully parse: lrc - padding=" ", width=10, paths=default', function() {
+		it('should successfully parse: left/right/center - padding=" ", width=10', function() {
 			const result=parse("${10l}|${10c}|${10r}", "left      |  center  |     right");
 			assert.deepStrictEqual(result, ["left", "center", "right"]);
 		});
 
-		it('should successfully parse: lrc - padding=".", width=15, paths=indexes', function() {
+		it('should successfully parse: left/right/center - padding=".", width=15, paths=indexes', function() {
 			const result=parse("${0:.15l}|${1:.15c}|${0:.15r}", "element-0......|...element-1...|......element-0");
 			assert.deepStrictEqual(result, ["element-0", "element-1"]);
 		});
 
-		it('should successfully parse: lrc - padding=".", width=15, paths=indexes', function() {
+		it('should successfully parse: left/right/center - padding=".", width=15, paths=indexes', function() {
 			const result=parse("${left:.15l}|${center:.15c}|${right:.15r}", "leftie.........|...dead-eye....|........rightie");
 			assert.deepStrictEqual(result, {"left": "leftie", "center": "dead-eye", "right": "rightie"});
+		});
+
+		it("should successfully parse: fields and literals - padding=[none], paths=default, width=[none]", function() {
+			const result=parse("${li} + ${li} = ${li}", "50 + 25 = 75");
+			assert.deepStrictEqual(result, [50, 25, 75]);
+		});
+
+		it("should successfully parse: fields and literals - padding=[none], paths=default, width=[none]", function() {
+			const result=parse("${lf} + ${lf} = ${lf}", "50.5 + 25.25 = 75.75");
+			assert.deepStrictEqual(result, [50.5, 25.25, 75.75]);
+		});
+
+		it("should successfully parse: fields and literals - padding=[none], paths=default, width=[none]", function() {
+			const result=parse("${lf} + ${lf} ~= ${lf}", "50.5 + 25.25 ~= 75.8");
+			assert.deepStrictEqual(result, [50.5, 25.25, 75.8]);
 		});
 	});
 });


### PR DESCRIPTION
- add some field and literal format and parsing examples.
- revealed more areas where where we need to escape reserved regex characters.
- also revealed deficiency with supporting floating point precision. Remove support all together.
- move escape functionality to _utils so that we may test it separately
- update readme with revisions and add examples